### PR TITLE
Create Air Now

### DIFF
--- a/Air Now
+++ b/Air Now
@@ -1,0 +1,10 @@
+<iframe
+src="//www.epa.gov/cgi-bin/widget.cgi?27711"
+id="airnow"
+width="293"
+height="185"
+scrolling="no"
+frameborder="0"
+marginwidth="3"
+marginheight="0">
+</iframe>


### PR DESCRIPTION
Now you can provide current air quality information: right on your own web page! A new, free widget from the Environmental Protection Agency allows your organization to post today’s air quality forecast directly on your home page. Add the line of code below to your web page and the widget will display the correct data for your zip code.

The widget will allow your organization to provide real-time air quality data to the people you want to reach. Children and the elderly are particularly susceptible to air pollution, which can harm their lungs and hearts. The Air Quality Index helps people track when the air pollution levels are in an unhealthy range so they can modify their activities as necessary to protect their health.

Note: Change the zipcode in the url string: //www.epa.gov/cgi-bin/widget.cgi?ZIPCODE